### PR TITLE
feat: option to use external sign and public key when creating trx

### DIFF
--- a/src/chain/trx.ts
+++ b/src/chain/trx.ts
@@ -27,6 +27,8 @@ export const create = async (p: ICreateObjectPayload) => {
     data: p.object,
     privateKey: p.privateKey,
     aesKey: group!.cipherKey
+    publicKey: p.publicKey,
+    sign: p.sign,
   });
   const apiURL = new URL(group!.chainAPIs[0]);
   const res = await (axios.post(`${apiURL.origin}/api/v1/node/trx/${p.groupId}`, payload, {

--- a/src/chain/types/trx.ts
+++ b/src/chain/types/trx.ts
@@ -21,6 +21,8 @@ export interface ICreateObjectPayload {
   object: IObject;
   aesKey: string;
   privateKey?: string;
+  publicKey?: string
+  sign?: (hash: string) => string | Promise<string>
 }
 
 export interface ICreatePersonPayload {

--- a/src/utils/types/signTrx.ts
+++ b/src/utils/types/signTrx.ts
@@ -7,4 +7,6 @@ export interface ISignTrxPayload {
   data: IObject | IPerson;
   aesKey: string;
   privateKey?: string;
+  publicKey?: string
+  sign?: (hash: string) => string | Promise<string>
 }


### PR DESCRIPTION
`trx.create` 参数新增了2个字段
```ts
interface A {
  publicKey?: string
  sign?: (hash: string) => string | Promise<string>
}
```